### PR TITLE
Update JEDI to JEG in ministry-names.json

### DIFF
--- a/ministry-names.json
+++ b/ministry-names.json
@@ -71,8 +71,8 @@
       "sector": "Economy Sector"
     },
     {
-      "name": "Jobs, Economic Development and Innovation",
-      "acronym": "JEDI",
+      "name": "Jobs and Economic Growth",
+      "acronym": "JEG",
       "sector": "Economy Sector"
     },
     {


### PR DESCRIPTION
Updated Jobs, Economic Development and Innovation to Jobs and Economic Growth. Name was changed on July 17th. https://intranet.gov.bc.ca/economy-sector/jeg/executive-team/dm-update-july-17-ministry-changes